### PR TITLE
Add plugin to centralize WordPress admin notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# FP-Admin-Notices
+# FP Admin Notices
+
+Un plugin WordPress che centralizza le notice del back-end in un pannello dedicato, apribile dall'admin bar senza ricaricare la pagina.
+
+## Funzionalità
+
+- Raccoglie automaticamente tutte le notice (`success`, `warning`, `error`, `info`) mostrate nel back-end corrente.
+- Nasconde le notice dall'intestazione delle pagine di amministrazione e le ripropone in un pannello sempre disponibile.
+- Pannello accessibile dall'admin bar con conteggio delle notice non lette.
+- Apertura/chiusura dinamica senza ricaricare la pagina, con osservazione in tempo reale di nuove notice tramite `MutationObserver`.
+- Interfaccia responsive con overlay e gestione focus per migliorare l'accessibilità.
+
+## Installazione
+
+1. Copia la cartella del plugin nella directory `wp-content/plugins/` del tuo sito WordPress.
+2. Accedi alla dashboard di WordPress e attiva **FP Admin Notices** dalla sezione **Plugin**.
+
+## Utilizzo
+
+- Dopo l'attivazione troverai un'icona a forma di megafono nell'admin bar (in alto a destra).
+- Il badge rosso mostra il numero di notice disponibili. Cliccando l'icona si apre il pannello con l'elenco delle notice.
+- Puoi chiudere il pannello cliccando l'overlay, il pulsante di chiusura o premendo `Esc`.
+
+## Personalizzazione
+
+Il plugin espone i file CSS e JS in `assets/`. Puoi sovrascrivere gli stili nel tuo tema o child theme se necessario.
+
+## Requisiti
+
+- WordPress 5.8 o superiore.
+- PHP 7.2 o superiore.

--- a/assets/css/admin-notices.css
+++ b/assets/css/admin-notices.css
@@ -1,0 +1,121 @@
+#wp-admin-bar-fp-admin-notices-toggle > .ab-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+#wp-admin-bar-fp-admin-notices-toggle .fp-admin-notices-count {
+    display: inline-flex;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    font-size: 11px;
+    border-radius: 999px;
+    background-color: #d63638;
+    color: #fff;
+    justify-content: center;
+    align-items: center;
+    font-weight: 600;
+}
+
+#wp-admin-bar-fp-admin-notices-toggle .fp-admin-notices-count:not(.has-items) {
+    display: none;
+}
+
+.fp-admin-notices-panel {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.fp-admin-notices-panel.is-open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.fp-admin-notices-panel__overlay {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.35);
+}
+
+.fp-admin-notices-panel__content {
+    position: absolute;
+    top: calc(var(--wp-admin-bar-height, 32px) + 12px);
+    right: 20px;
+    width: min(480px, 90vw);
+    max-height: calc(100vh - 64px);
+    background: #fff;
+    border-radius: 6px;
+    box-shadow: 0 18px 40px rgba(30, 35, 90, 0.25);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+@media screen and (max-width: 782px) {
+    .fp-admin-notices-panel__content {
+        top: calc(var(--wp-admin-bar-height, 46px) + 12px);
+        right: 12px;
+        left: 12px;
+        width: auto;
+    }
+}
+
+.fp-admin-notices-panel__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid #dcdcde;
+}
+
+.fp-admin-notices-panel__header h2 {
+    margin: 0;
+    font-size: 16px;
+    line-height: 1.4;
+}
+
+.fp-admin-notices-panel__close {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: #50575e;
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.fp-admin-notices-panel__body {
+    padding: 16px 20px;
+    overflow-y: auto;
+    outline: none;
+}
+
+.fp-admin-notices-panel__body:focus {
+    box-shadow: 0 0 0 2px #2271b1 inset;
+}
+
+.fp-admin-notices-panel__item {
+    margin: 0 0 16px;
+}
+
+.fp-admin-notices-panel__item:last-child {
+    margin-bottom: 0;
+}
+
+.fp-admin-notices-panel__item .notice-dismiss {
+    display: none;
+}
+
+.fp-admin-notices-panel__empty {
+    margin: 0;
+    color: #50575e;
+}
+
+.fp-admin-notices-hidden {
+    display: none !important;
+}

--- a/assets/js/admin-notices.js
+++ b/assets/js/admin-notices.js
@@ -1,0 +1,228 @@
+(function () {
+    'use strict';
+
+    var data = window.FPAdminNotices || {};
+    var i18n = data.i18n || {};
+
+    function ready(fn) {
+        if (document.readyState !== 'loading') {
+            fn();
+        } else {
+            document.addEventListener('DOMContentLoaded', fn, { once: true });
+        }
+    }
+
+    function qs(selector, context) {
+        return (context || document).querySelector(selector);
+    }
+
+    function qsa(selector, context) {
+        return Array.prototype.slice.call((context || document).querySelectorAll(selector));
+    }
+
+    function collectNoticeElements() {
+        var selectors = [
+            '#wpbody-content .notice',
+            '#wpbody-content .update-nag',
+            '#wpbody-content .error',
+            '#wpbody-content .updated'
+        ];
+        var elements = [];
+
+        selectors.forEach(function (selector) {
+            qsa(selector).forEach(function (node) {
+                if (!node.closest('#fp-admin-notices-panel') && elements.indexOf(node) === -1) {
+                    elements.push(node);
+                }
+            });
+        });
+
+        return elements;
+    }
+
+    function stripDismissButtons(node) {
+        qsa('.notice-dismiss, .dismiss-notice', node).forEach(function (btn) {
+            btn.remove();
+        });
+        return node;
+    }
+
+    function cloneNotice(node) {
+        var clone = node.cloneNode(true);
+        clone.classList.add('fp-admin-notices-panel__item');
+        clone.classList.remove('is-dismissible');
+        return stripDismissButtons(clone);
+    }
+
+    function hideOriginalNotice(node) {
+        node.classList.add('fp-admin-notices-hidden');
+        node.setAttribute('data-fp-admin-notices', 'hidden');
+    }
+
+    function updateCount(toggle, count) {
+        if (!toggle) {
+            return;
+        }
+
+        var badge = qs('.fp-admin-notices-count', toggle);
+        var label = i18n.title || 'Notifiche';
+        var anchor = qs('a', toggle);
+
+        if (badge) {
+            badge.textContent = count > 0 ? String(count) : '';
+            badge.classList.toggle('has-items', count > 0);
+        }
+
+        if (anchor) {
+            var ariaLabel = count > 0 ? label + ' (' + count + ')' : label;
+            anchor.setAttribute('aria-label', ariaLabel);
+            anchor.setAttribute('aria-expanded', anchor.classList.contains('is-active') ? 'true' : 'false');
+        }
+    }
+
+    function renderNotices(panel, toggle) {
+        var list = qs('.fp-admin-notices-panel__list', panel);
+        if (!list) {
+            return;
+        }
+
+        list.innerHTML = '';
+        var notices = collectNoticeElements();
+
+        if (notices.length === 0) {
+            var emptyMessage = document.createElement('p');
+            emptyMessage.className = 'fp-admin-notices-panel__empty';
+            emptyMessage.textContent = i18n.noNotices || '';
+            list.appendChild(emptyMessage);
+            updateCount(toggle, 0);
+            return;
+        }
+
+        notices.forEach(function (notice) {
+            hideOriginalNotice(notice);
+            list.appendChild(cloneNotice(notice));
+        });
+
+        updateCount(toggle, notices.length);
+    }
+
+    function openPanel(panel, toggle, previouslyFocused) {
+        if (!panel) {
+            return;
+        }
+
+        panel.classList.add('is-open');
+        panel.setAttribute('aria-hidden', 'false');
+
+        if (toggle) {
+            var anchor = qs('a', toggle);
+            if (anchor) {
+                anchor.classList.add('is-active');
+                anchor.setAttribute('aria-expanded', 'true');
+            }
+        }
+
+        var focusTarget = qs('.fp-admin-notices-panel__body', panel);
+        if (focusTarget) {
+            focusTarget.focus({ preventScroll: true });
+        }
+
+        panel.dataset.fpAdminNoticesLastFocus = previouslyFocused ? previouslyFocused.id || 'custom-focus' : '';
+    }
+
+    function closePanel(panel, toggle) {
+        if (!panel) {
+            return;
+        }
+
+        panel.classList.remove('is-open');
+        panel.setAttribute('aria-hidden', 'true');
+
+        if (toggle) {
+            var anchor = qs('a', toggle);
+            if (anchor) {
+                anchor.classList.remove('is-active');
+                anchor.setAttribute('aria-expanded', 'false');
+                anchor.focus({ preventScroll: true });
+            }
+        }
+    }
+
+    function setupMutationObserver(panel, toggle) {
+        var target = qs('#wpbody-content');
+        if (!target) {
+            return;
+        }
+
+        var scheduled = false;
+        var observer = new MutationObserver(function () {
+            if (!scheduled) {
+                scheduled = true;
+                window.requestAnimationFrame(function () {
+                    renderNotices(panel, toggle);
+                    scheduled = false;
+                });
+            }
+        });
+
+        observer.observe(target, {
+            childList: true,
+            subtree: true
+        });
+    }
+
+    ready(function () {
+        var panel = document.getElementById('fp-admin-notices-panel');
+        var toggle = document.getElementById('wp-admin-bar-fp-admin-notices-toggle');
+
+        if (!panel || !toggle) {
+            return;
+        }
+
+        renderNotices(panel, toggle);
+        setupMutationObserver(panel, toggle);
+
+        var overlay = qs('.fp-admin-notices-panel__overlay', panel);
+        var closeButton = qs('.fp-admin-notices-panel__close', panel);
+
+        function togglePanel(event) {
+            event.preventDefault();
+            var isOpen = panel.classList.contains('is-open');
+            if (isOpen) {
+                closePanel(panel, toggle);
+            } else {
+                var activeElement = document.activeElement;
+                openPanel(panel, toggle, activeElement);
+            }
+        }
+
+        if (toggle) {
+            toggle.addEventListener('click', togglePanel);
+            toggle.addEventListener('keydown', function (event) {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    togglePanel(event);
+                }
+            });
+        }
+
+        if (overlay) {
+            overlay.addEventListener('click', function (event) {
+                event.preventDefault();
+                closePanel(panel, toggle);
+            });
+        }
+
+        if (closeButton) {
+            closeButton.addEventListener('click', function (event) {
+                event.preventDefault();
+                closePanel(panel, toggle);
+            });
+        }
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape' && panel.classList.contains('is-open')) {
+                closePanel(panel, toggle);
+            }
+        });
+    });
+})();

--- a/fp-admin-notices.php
+++ b/fp-admin-notices.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Plugin Name: FP Admin Notices
+ * Description: Centralizza le admin notices di WordPress in un pannello accessibile dall'admin bar.
+ * Version: 1.0.0
+ * Author: FP
+ * Text Domain: fp-admin-notices
+ * Domain Path: /languages
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'FP_Admin_Notices' ) ) {
+    /**
+     * Gestisce il pannello delle admin notices.
+     */
+    class FP_Admin_Notices {
+        /**
+         * Avvia gli hook principali del plugin.
+         */
+        public static function init() {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+            add_action( 'admin_footer', array( __CLASS__, 'render_panel_markup' ) );
+            add_action( 'admin_bar_menu', array( __CLASS__, 'register_admin_bar_entry' ), 100 );
+        }
+
+        /**
+         * Restituisce la versione del plugin.
+         *
+         * @return string
+         */
+        protected static function get_version() {
+            static $version = null;
+
+            if ( null === $version ) {
+                $plugin_file = __FILE__;
+                $version     = defined( 'WP_DEBUG' ) && WP_DEBUG
+                    ? filemtime( $plugin_file )
+                    : '1.0.0';
+            }
+
+            return (string) $version;
+        }
+
+        /**
+         * Carica gli assets nel back-end.
+         */
+        public static function enqueue_assets() {
+            $handle  = 'fp-admin-notices';
+            $version = self::get_version();
+
+            wp_enqueue_style(
+                $handle,
+                plugin_dir_url( __FILE__ ) . 'assets/css/admin-notices.css',
+                array(),
+                $version
+            );
+
+            wp_enqueue_script(
+                $handle,
+                plugin_dir_url( __FILE__ ) . 'assets/js/admin-notices.js',
+                array(),
+                $version,
+                true
+            );
+
+            wp_localize_script(
+                $handle,
+                'FPAdminNotices',
+                array(
+                    'i18n' => array(
+                        'title'      => __( 'Notifiche', 'fp-admin-notices' ),
+                        'noNotices'  => __( 'Nessuna notifica da mostrare.', 'fp-admin-notices' ),
+                        'openPanel'  => __( 'Apri il pannello notifiche', 'fp-admin-notices' ),
+                        'closePanel' => __( 'Chiudi il pannello notifiche', 'fp-admin-notices' ),
+                    ),
+                )
+            );
+        }
+
+        /**
+         * Registra la voce nell'admin bar.
+         *
+         * @param WP_Admin_Bar $admin_bar Istanza della admin bar.
+         */
+        public static function register_admin_bar_entry( $admin_bar ) {
+            if ( ! current_user_can( 'read' ) ) {
+                return;
+            }
+
+            $admin_bar->add_node(
+                array(
+                    'id'     => 'fp-admin-notices-toggle',
+                    'parent' => 'top-secondary',
+                    'title'  => '<span class="ab-icon dashicons dashicons-megaphone" aria-hidden="true"></span><span class="ab-label">' . esc_html__( 'Notifiche', 'fp-admin-notices' ) . '</span><span class="fp-admin-notices-count" aria-hidden="true"></span>',
+                    'href'   => '#',
+                    'meta'   => array(
+                        'title' => esc_attr__( 'Apri il pannello delle notifiche', 'fp-admin-notices' ),
+                        'class' => 'fp-admin-notices-toggle',
+                    ),
+                )
+            );
+        }
+
+        /**
+         * Stampa il markup del pannello nel footer amministrativo.
+         */
+        public static function render_panel_markup() {
+            if ( ! current_user_can( 'read' ) ) {
+                return;
+            }
+            ?>
+            <div id="fp-admin-notices-panel" class="fp-admin-notices-panel" aria-hidden="true" role="dialog" aria-labelledby="fp-admin-notices-title">
+                <div class="fp-admin-notices-panel__overlay" tabindex="-1"></div>
+                <div class="fp-admin-notices-panel__content" role="document">
+                    <header class="fp-admin-notices-panel__header">
+                        <h2 id="fp-admin-notices-title"><?php esc_html_e( 'Notifiche amministratore', 'fp-admin-notices' ); ?></h2>
+                        <button type="button" class="fp-admin-notices-panel__close" aria-label="<?php echo esc_attr_x( 'Chiudi', 'close panel button', 'fp-admin-notices' ); ?>">&times;</button>
+                    </header>
+                    <div class="fp-admin-notices-panel__body" tabindex="0">
+                        <div class="fp-admin-notices-panel__list" role="region" aria-live="polite" aria-relevant="all"></div>
+                    </div>
+                </div>
+            </div>
+            <?php
+        }
+    }
+}
+
+FP_Admin_Notices::init();


### PR DESCRIPTION
## Summary
- add FP Admin Notices plugin bootstrap with admin bar toggle and notice panel
- enqueue custom CSS/JS to hide native notices and display them inside an accessible overlay
- document installation and usage instructions in README

## Testing
- php -l fp-admin-notices.php

------
https://chatgpt.com/codex/tasks/task_e_68d552acadb8832fa116f88de8d7c72c