### PR TITLE
Add bulk notice controls and REST batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ Un plugin WordPress che centralizza le notice del back-end in un pannello dedica
 
 - Raccoglie automaticamente tutte le notice (`success`, `warning`, `error`, `info`) mostrate nel back-end corrente.
 - Nasconde le notice dall'intestazione delle pagine di amministrazione e le ripropone in un pannello sempre disponibile.
-- Pannello accessibile dall'admin bar con conteggio delle notice non lette.
-- Apertura/chiusura dinamica senza ricaricare la pagina, con osservazione in tempo reale di nuove notice tramite `MutationObserver`.
-- Interfaccia responsive con overlay e gestione focus per migliorare l'accessibilità.
+- Pannello accessibile dall'admin bar con conteggio delle notice non lette e annuncio vocale delle nuove comunicazioni.
+- Possibilità di segnare le singole notice come lette/non lette con persistenza per utente tramite REST API.
+- Azioni rapide per segnare tutte le notice visibili come lette/non lette e mostrare/nascondere quelle archiviate.
+- Filtri per severità, campo di ricerca e scorciatoia da tastiera (`Alt` + `Shift` + `N`) per un accesso rapido.
+- Apertura/chiusura dinamica senza ricaricare la pagina, con osservazione in tempo reale di nuove notice tramite `MutationObserver` e apertura automatica per gli errori critici (opzionale).
+- Interfaccia responsive con overlay, focus trap e controlli tastiera per migliorare l'accessibilità.
 
 ## Installazione
 
@@ -18,12 +21,24 @@ Un plugin WordPress che centralizza le notice del back-end in un pannello dedica
 ## Utilizzo
 
 - Dopo l'attivazione troverai un'icona a forma di megafono nell'admin bar (in alto a destra).
-- Il badge rosso mostra il numero di notice disponibili. Cliccando l'icona si apre il pannello con l'elenco delle notice.
-- Puoi chiudere il pannello cliccando l'overlay, il pulsante di chiusura o premendo `Esc`.
+- Il badge rosso mostra il numero di notice non lette. Cliccando l'icona si apre il pannello con l'elenco delle notice.
+- Puoi filtrare per severità, cercare testualmente e segnare le singole notice come lette/non lette oppure mostrarle nuovamente nella pagina.
+- Dal gruppo di **Azioni rapide** puoi archiviare o ripristinare tutte le notice filtrate e scegliere se visualizzare anche quelle già archiviate.
+- Il pannello può essere chiuso cliccando l'overlay, il pulsante di chiusura o premendo `Esc`. Premi `Alt` + `Shift` + `N` per aprirlo/chiuderlo rapidamente.
+
+### Impostazioni
+
+- Dal menu **Impostazioni → Pannello notifiche** puoi scegliere quali ruoli possano vedere il pannello, includere o meno gli avvisi di aggiornamento (`update nag`), decidere se aprire automaticamente il pannello quando arriva un errore critico e limitare il caricamento alle schermate amministrative che preferisci.
 
 ## Personalizzazione
 
 Il plugin espone i file CSS e JS in `assets/`. Puoi sovrascrivere gli stili nel tuo tema o child theme se necessario.
+
+### Hook disponibili
+
+- `fp_admin_notices_allowed_screens`: modifica dinamicamente l'elenco di screen ID su cui caricare il pannello.
+- `fp_admin_notices_should_render`: forza l'attivazione o l'esclusione del pannello per una determinata schermata (`WP_Screen`).
+- Evento JS `fpAdminNotices:listUpdated`: emesso ogni volta che l'elenco viene renderizzato, con dettagli su filtri e notice visibili.
 
 ## Requisiti
 

--- a/assets/css/admin-notices.css
+++ b/assets/css/admin-notices.css
@@ -89,8 +89,86 @@
     cursor: pointer;
 }
 
+.fp-admin-notices-panel__controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 20px 0;
+}
+
+.fp-admin-notices-panel__bulk-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 20px 0;
+}
+
+.fp-admin-notices-panel__bulk-action {
+    appearance: none;
+    border: 1px solid #c3c4c7;
+    background: #fff;
+    color: #1d2327;
+    border-radius: 4px;
+    padding: 4px 12px;
+    font-size: 12px;
+    line-height: 1.4;
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.fp-admin-notices-panel__bulk-action:hover,
+.fp-admin-notices-panel__bulk-action:focus {
+    border-color: #2271b1;
+    color: #2271b1;
+    outline: none;
+}
+
+.fp-admin-notices-panel__bulk-action:disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
+.fp-admin-notices-panel__bulk-action[aria-pressed="true"] {
+    background: #2271b1;
+    border-color: #2271b1;
+    color: #fff;
+}
+
+.fp-admin-notices-panel__filters {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.fp-admin-notices-filter {
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid #c3c4c7;
+    background: #f6f7f7;
+    color: #1d2327;
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.fp-admin-notices-filter.is-active {
+    background: #2271b1;
+    border-color: #2271b1;
+    color: #fff;
+}
+
+.fp-admin-notices-search {
+    flex: 1 1 160px;
+    min-width: 140px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    border: 1px solid #c3c4c7;
+    font-size: 13px;
+}
+
 .fp-admin-notices-panel__body {
-    padding: 16px 20px;
+    padding: 12px 20px 20px;
     overflow-y: auto;
     outline: none;
 }
@@ -101,14 +179,54 @@
 
 .fp-admin-notices-panel__item {
     margin: 0 0 16px;
+    position: relative;
 }
 
 .fp-admin-notices-panel__item:last-child {
     margin-bottom: 0;
 }
 
+.fp-admin-notices-panel__item.is-dismissed {
+    opacity: 0.6;
+}
+
+.fp-admin-notices-panel__item--error {
+    border-left: 4px solid #d63638;
+}
+
+.fp-admin-notices-panel__item--warning {
+    border-left: 4px solid #f0c33c;
+}
+
+.fp-admin-notices-panel__item--success {
+    border-left: 4px solid #00a32a;
+}
+
+.fp-admin-notices-panel__item--info {
+    border-left: 4px solid #3858e9;
+}
+
 .fp-admin-notices-panel__item .notice-dismiss {
     display: none;
+}
+
+.fp-admin-notices-panel__actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 12px;
+    flex-wrap: wrap;
+}
+
+.fp-admin-notices-panel__action {
+    color: #2271b1;
+    cursor: pointer;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.fp-admin-notices-panel__action:hover,
+.fp-admin-notices-panel__action:focus {
+    text-decoration: underline;
 }
 
 .fp-admin-notices-panel__empty {
@@ -118,4 +236,17 @@
 
 .fp-admin-notices-hidden {
     display: none !important;
+}
+
+.fp-admin-notices-highlight {
+    animation: fp-admin-notices-highlight 2s ease;
+}
+
+@keyframes fp-admin-notices-highlight {
+    0% {
+        box-shadow: 0 0 0 0 rgba(34, 113, 177, 0.75);
+    }
+    100% {
+        box-shadow: 0 0 0 8px rgba(34, 113, 177, 0);
+    }
 }

--- a/assets/js/admin-notices.js
+++ b/assets/js/admin-notices.js
@@ -3,6 +3,38 @@
 
     var data = window.FPAdminNotices || {};
     var i18n = data.i18n || {};
+    var settings = data.settings || {};
+    var dismissedInitial = Array.isArray(data.dismissed) ? data.dismissed : [];
+    var state = {
+        notices: [],
+        filter: 'all',
+        search: '',
+        showDismissed: false,
+        dismissed: new Set(dismissedInitial),
+        includeUpdateNag: !!settings.includeUpdateNag,
+        autoOpenCritical: !!settings.autoOpenCritical
+    };
+
+    var restConfig = data.rest || {};
+    var lastFocusedElement = null;
+    var focusTrapHandler = null;
+    var previousActiveCount = 0;
+    var panelEl = null;
+    var toggleEl = null;
+    var bulkActionEls = {
+        markRead: null,
+        markUnread: null,
+        toggleArchived: null
+    };
+
+    function emit(eventName, detail) {
+        if (typeof window.CustomEvent !== 'function') {
+            return;
+        }
+        document.dispatchEvent(new CustomEvent(eventName, {
+            detail: detail || {}
+        }));
+    }
 
     function ready(fn) {
         if (document.readyState !== 'loading') {
@@ -20,19 +52,77 @@
         return Array.prototype.slice.call((context || document).querySelectorAll(selector));
     }
 
+    function hashString(str) {
+        var hash = 0;
+        if (!str) {
+            return hash;
+        }
+        for (var i = 0; i < str.length; i++) {
+            hash = (hash << 5) - hash + str.charCodeAt(i);
+            hash |= 0; // Convert to 32bit integer
+        }
+        return hash;
+    }
+
+    function ensureNoticeId(node) {
+        if (!node) {
+            return '';
+        }
+        if (node.dataset.fpAdminNoticeId) {
+            return node.dataset.fpAdminNoticeId;
+        }
+        var base = (node.id || '') + '|' + (node.className || '') + '|' + (node.textContent || '');
+        var hash = hashString(base.trim());
+        var id = 'fp-notice-' + Math.abs(hash);
+        node.dataset.fpAdminNoticeId = id;
+        return id;
+    }
+
+    function getSeverity(node) {
+        if (!node) {
+            return 'info';
+        }
+        if (node.classList.contains('notice-error') || node.classList.contains('error')) {
+            return 'error';
+        }
+        if (node.classList.contains('notice-warning') || node.classList.contains('update-nag') || node.classList.contains('warning')) {
+            return 'warning';
+        }
+        if (node.classList.contains('notice-success') || node.classList.contains('updated') || node.classList.contains('success')) {
+            return 'success';
+        }
+        return 'info';
+    }
+
+    function shouldIncludeNotice(node) {
+        if (!node) {
+            return false;
+        }
+        if (!state.includeUpdateNag && node.classList.contains('update-nag')) {
+            return false;
+        }
+        return true;
+    }
+
     function collectNoticeElements() {
         var selectors = [
             '#wpbody-content .notice',
-            '#wpbody-content .update-nag',
             '#wpbody-content .error',
             '#wpbody-content .updated'
         ];
+
+        if (state.includeUpdateNag) {
+            selectors.push('#wpbody-content .update-nag');
+        }
+
         var elements = [];
 
         selectors.forEach(function (selector) {
             qsa(selector).forEach(function (node) {
                 if (!node.closest('#fp-admin-notices-panel') && elements.indexOf(node) === -1) {
-                    elements.push(node);
+                    if (shouldIncludeNotice(node)) {
+                        elements.push(node);
+                    }
                 }
             });
         });
@@ -51,12 +141,51 @@
         var clone = node.cloneNode(true);
         clone.classList.add('fp-admin-notices-panel__item');
         clone.classList.remove('is-dismissible');
-        return stripDismissButtons(clone);
+        clone.classList.remove('fp-admin-notices-hidden');
+        clone.classList.remove('fp-admin-notices-highlight');
+        clone.removeAttribute('style');
+        stripDismissButtons(clone);
+        return clone;
     }
 
     function hideOriginalNotice(node) {
+        if (!node) {
+            return;
+        }
         node.classList.add('fp-admin-notices-hidden');
         node.setAttribute('data-fp-admin-notices', 'hidden');
+    }
+
+    function showOriginalNotice(notice) {
+        if (!notice || !notice.node) {
+            return;
+        }
+        var node = notice.node;
+        node.classList.remove('fp-admin-notices-hidden');
+        node.removeAttribute('data-fp-admin-notices');
+        node.classList.add('fp-admin-notices-highlight');
+        var hadTabindex = node.hasAttribute('tabindex');
+        var previousTabindex = hadTabindex ? node.getAttribute('tabindex') : null;
+
+        if (!hadTabindex) {
+            node.setAttribute('tabindex', '-1');
+        }
+
+        node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        try {
+            node.focus({ preventScroll: true });
+        } catch (err) {
+            // Some elements cannot receive focus; ignore.
+        }
+
+        window.setTimeout(function () {
+            node.classList.remove('fp-admin-notices-highlight');
+            if (!hadTabindex) {
+                node.removeAttribute('tabindex');
+            } else if (previousTabindex !== null) {
+                node.setAttribute('tabindex', previousTabindex);
+            }
+        }, 2000);
     }
 
     function formatAriaLabel(baseLabel, count) {
@@ -67,99 +196,392 @@
         return count > 0 ? baseLabel + ' (' + count + ')' : baseLabel;
     }
 
-    function updateCount(toggle, count) {
-        if (!toggle) {
+    function getActiveNotices() {
+        return state.notices.filter(function (notice) {
+            return !notice.dismissed;
+        });
+    }
+
+    function matchesFilters(notice) {
+        if (!notice) {
+            return false;
+        }
+        if (state.filter !== 'all' && notice.severity !== state.filter) {
+            return false;
+        }
+        if (state.search) {
+            return notice.text.toLowerCase().indexOf(state.search) !== -1;
+        }
+        return true;
+    }
+
+    function getFilteredNotices(options) {
+        options = options || {};
+        var includeDismissed = !!options.includeDismissed;
+
+        return state.notices.filter(function (notice) {
+            if (!matchesFilters(notice)) {
+                return false;
+            }
+            if (!includeDismissed && notice.dismissed) {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    function ensureBulkActionElements() {
+        if (!panelEl) {
+            return;
+        }
+        if (!bulkActionEls.markRead) {
+            bulkActionEls.markRead = qs('.fp-admin-notices-panel__bulk-action--read', panelEl);
+        }
+        if (!bulkActionEls.markUnread) {
+            bulkActionEls.markUnread = qs('.fp-admin-notices-panel__bulk-action--unread', panelEl);
+        }
+        if (!bulkActionEls.toggleArchived) {
+            bulkActionEls.toggleArchived = qs('.fp-admin-notices-panel__bulk-action--toggle-archived', panelEl);
+        }
+    }
+
+    function updateBulkActionsState() {
+        ensureBulkActionElements();
+
+        var available = getFilteredNotices({ includeDismissed: true });
+        var hasUnread = available.some(function (notice) {
+            return !notice.dismissed;
+        });
+        var hasArchived = available.some(function (notice) {
+            return notice.dismissed;
+        });
+
+        if (bulkActionEls.markRead) {
+            if (i18n.markAllRead) {
+                bulkActionEls.markRead.textContent = i18n.markAllRead;
+                bulkActionEls.markRead.setAttribute('title', i18n.markAllRead);
+            }
+            bulkActionEls.markRead.disabled = !hasUnread;
+        }
+
+        if (bulkActionEls.markUnread) {
+            if (i18n.markAllUnread) {
+                bulkActionEls.markUnread.textContent = i18n.markAllUnread;
+                bulkActionEls.markUnread.setAttribute('title', i18n.markAllUnread);
+            }
+            bulkActionEls.markUnread.disabled = !hasArchived;
+        }
+
+        if (bulkActionEls.toggleArchived) {
+            bulkActionEls.toggleArchived.setAttribute('aria-pressed', state.showDismissed ? 'true' : 'false');
+            var label = state.showDismissed
+                ? (i18n.hideDismissed || 'Nascondi archiviate')
+                : (i18n.showDismissed || 'Mostra archiviate');
+            bulkActionEls.toggleArchived.textContent = label;
+            bulkActionEls.toggleArchived.setAttribute('title', label);
+        }
+    }
+
+    function updateCount() {
+        if (!toggleEl) {
             return;
         }
 
-        var badge = qs('.fp-admin-notices-count', toggle);
+        var activeNotices = getActiveNotices();
+        var count = activeNotices.length;
+        var badge = qs('.fp-admin-notices-count', toggleEl);
         var label = i18n.title || 'Notifiche';
-        var anchor = qs('a', toggle);
+        var anchor = qs('a', toggleEl);
 
         if (badge) {
             badge.textContent = count > 0 ? String(count) : '';
             badge.classList.toggle('has-items', count > 0);
         }
 
-        toggle.dataset.fpAdminNoticesCount = String(count);
+        toggleEl.dataset.fpAdminNoticesCount = String(count);
 
         if (anchor) {
             var isActive = anchor.classList.contains('is-active');
-            var baseLabel = isActive
-                ? (i18n.closePanel || label)
-                : (i18n.openPanel || label);
+            var baseLabel = isActive ? (i18n.closePanel || label) : (i18n.openPanel || label);
             anchor.setAttribute('aria-label', formatAriaLabel(baseLabel, count));
             anchor.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+            if (i18n.toggleShortcut) {
+                anchor.setAttribute('title', i18n.toggleShortcut);
+            }
         }
+
+        if (count > previousActiveCount) {
+            announce(i18n.newNoticeAnnouncement || '');
+        }
+
+        previousActiveCount = count;
     }
 
-    function renderNotices(panel, toggle) {
-        var list = qs('.fp-admin-notices-panel__list', panel);
+    function announce(message) {
+        if (!message || !panelEl) {
+            return;
+        }
+        var announcer = qs('.fp-admin-notices-panel__announcement', panelEl);
+        if (!announcer) {
+            return;
+        }
+        announcer.textContent = '';
+        window.requestAnimationFrame(function () {
+            announcer.textContent = message;
+        });
+    }
+
+    function createActions(notice) {
+        var actions = document.createElement('div');
+        actions.className = 'fp-admin-notices-panel__actions';
+
+        var toggleBtn = document.createElement('button');
+        toggleBtn.type = 'button';
+        toggleBtn.className = 'fp-admin-notices-panel__action button-link fp-admin-notices-panel__action--toggle';
+        toggleBtn.textContent = notice.dismissed ? (i18n.markUnread || 'Segna come non letta') : (i18n.markRead || 'Segna come letta');
+        toggleBtn.addEventListener('click', function (event) {
+            event.preventDefault();
+            setDismissed(notice, !notice.dismissed, true);
+        });
+        actions.appendChild(toggleBtn);
+
+        var showBtn = document.createElement('button');
+        showBtn.type = 'button';
+        showBtn.className = 'fp-admin-notices-panel__action button-link fp-admin-notices-panel__action--show';
+        showBtn.textContent = i18n.showNotice || 'Mostra nella pagina';
+        showBtn.addEventListener('click', function (event) {
+            event.preventDefault();
+            showOriginalNotice(notice);
+            closePanel();
+        });
+        actions.appendChild(showBtn);
+
+        return actions;
+    }
+
+    function renderList() {
+        if (!panelEl) {
+            return;
+        }
+        var list = qs('.fp-admin-notices-panel__list', panelEl);
         if (!list) {
             return;
         }
 
         list.innerHTML = '';
-        var notices = collectNoticeElements();
 
-        if (notices.length === 0) {
-            var emptyMessage = document.createElement('p');
-            emptyMessage.className = 'fp-admin-notices-panel__empty';
-            emptyMessage.textContent = i18n.noNotices || '';
-            list.appendChild(emptyMessage);
-            updateCount(toggle, 0);
-            return;
-        }
-
-        notices.forEach(function (notice) {
-            hideOriginalNotice(notice);
-            list.appendChild(cloneNotice(notice));
+        var matches = getFilteredNotices({ includeDismissed: true });
+        var filtered = state.showDismissed ? matches : matches.filter(function (notice) {
+            return !notice.dismissed;
         });
 
-        updateCount(toggle, notices.length);
-    }
-
-    var lastFocusedElement = null;
-
-    function openPanel(panel, toggle) {
-        if (!panel) {
+        if (!filtered.length) {
+            var emptyMessage = document.createElement('p');
+            emptyMessage.className = 'fp-admin-notices-panel__empty';
+            if (state.notices.length === 0) {
+                emptyMessage.textContent = i18n.noNotices || '';
+            } else if (matches.length === 0) {
+                emptyMessage.textContent = i18n.noMatches || i18n.noNotices || '';
+            } else {
+                emptyMessage.textContent = i18n.noUnreadMatches || i18n.noNotices || '';
+            }
+            list.appendChild(emptyMessage);
+            emit('fpAdminNotices:listUpdated', {
+                notices: [],
+                filter: state.filter,
+                search: state.search,
+                showDismissed: state.showDismissed
+            });
+            updateBulkActionsState();
             return;
         }
 
-        panel.classList.add('is-open');
-        panel.setAttribute('aria-hidden', 'false');
+        var fragment = document.createDocumentFragment();
 
-        if (toggle) {
-            var anchor = qs('a', toggle);
+        filtered.forEach(function (notice) {
+            var item = cloneNotice(notice.node);
+            item.dataset.fpAdminNoticeId = notice.id;
+            item.classList.add('fp-admin-notices-panel__item');
+            item.classList.add('fp-admin-notices-panel__item--' + notice.severity);
+            if (notice.dismissed) {
+                item.classList.add('is-dismissed');
+            }
+            item.appendChild(createActions(notice));
+            fragment.appendChild(item);
+        });
+
+        list.appendChild(fragment);
+
+        emit('fpAdminNotices:listUpdated', {
+            notices: filtered.map(function (notice) {
+                return {
+                    id: notice.id,
+                    severity: notice.severity,
+                    dismissed: notice.dismissed,
+                    text: notice.text
+                };
+            }),
+            filter: state.filter,
+            search: state.search,
+            showDismissed: state.showDismissed
+        });
+
+        updateBulkActionsState();
+    }
+
+    function persistNoticeState(noticeIds, dismissed) {
+        if (!restConfig || !restConfig.url || typeof window.fetch !== 'function') {
+            return Promise.resolve();
+        }
+
+        if (Array.isArray(noticeIds) && !noticeIds.length) {
+            return Promise.resolve();
+        }
+
+        if (!Array.isArray(noticeIds) && !noticeIds) {
+            return Promise.resolve();
+        }
+
+        var payload = {
+            dismissed: dismissed
+        };
+
+        if (Array.isArray(noticeIds)) {
+            payload.notice_ids = noticeIds;
+        } else {
+            payload.notice_id = noticeIds;
+        }
+
+        return window.fetch(restConfig.url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-WP-Nonce': restConfig.nonce || ''
+            },
+            body: JSON.stringify(payload)
+        }).catch(function (error) {
+            // eslint-disable-next-line no-console
+            console.error('FP Admin Notices: unable to persist notice state', error);
+        });
+    }
+
+    function setDismissed(notice, dismissed, persist) {
+        if (!notice) {
+            return;
+        }
+
+        notice.dismissed = dismissed;
+        if (dismissed) {
+            state.dismissed.add(notice.id);
+        } else {
+            state.dismissed.delete(notice.id);
+            hideOriginalNotice(notice.node);
+        }
+
+        updateCount();
+        renderList();
+
+        if (persist) {
+            persistNoticeState(notice.id, dismissed);
+        }
+    }
+
+    function syncNotices() {
+        var nodes = collectNoticeElements();
+        var seen = {};
+        var newCritical = false;
+
+        nodes.forEach(function (node, index) {
+            var id = ensureNoticeId(node);
+            seen[id] = true;
+            var severity = getSeverity(node);
+            var text = (node.textContent || '').replace(/\s+/g, ' ').trim();
+            var existing = state.notices.find(function (item) {
+                return item.id === id;
+            });
+            var isDismissed = state.dismissed.has(id);
+            hideOriginalNotice(node);
+
+            if (!existing) {
+                existing = {
+                    id: id,
+                    node: node,
+                    severity: severity,
+                    text: text,
+                    dismissed: isDismissed,
+                    index: index
+                };
+                state.notices.push(existing);
+                if (!isDismissed && severity === 'error') {
+                    newCritical = true;
+                }
+            } else {
+                existing.node = node;
+                existing.severity = severity;
+                existing.text = text;
+                existing.dismissed = isDismissed;
+                existing.index = index;
+            }
+        });
+
+        state.notices = state.notices.filter(function (notice) {
+            return seen[notice.id];
+        });
+
+        state.notices.sort(function (a, b) {
+            return a.index - b.index;
+        });
+
+        return {
+            newCritical: newCritical
+        };
+    }
+
+    function openPanel() {
+        if (!panelEl) {
+            return;
+        }
+
+        panelEl.classList.add('is-open');
+        panelEl.setAttribute('aria-hidden', 'false');
+
+        if (toggleEl) {
+            var anchor = qs('a', toggleEl);
             if (anchor) {
                 anchor.classList.add('is-active');
                 anchor.setAttribute('aria-expanded', 'true');
-                var count = Number(toggle.dataset.fpAdminNoticesCount || '0');
+                var count = Number(toggleEl.dataset.fpAdminNoticesCount || '0');
                 var label = i18n.closePanel || i18n.title || 'Notifiche';
                 anchor.setAttribute('aria-label', formatAriaLabel(label, count));
             }
         }
 
         lastFocusedElement = document.activeElement;
-        var focusTarget = qs('.fp-admin-notices-panel__body', panel);
+        var focusTarget = qs('.fp-admin-notices-panel__body', panelEl);
         if (focusTarget) {
             focusTarget.focus({ preventScroll: true });
         }
+
+        enableFocusTrap();
+        emit('fpAdminNotices:open', {
+            count: getActiveNotices().length
+        });
     }
 
-    function closePanel(panel, toggle) {
-        if (!panel) {
+    function closePanel() {
+        if (!panelEl) {
             return;
         }
 
-        panel.classList.remove('is-open');
-        panel.setAttribute('aria-hidden', 'true');
+        panelEl.classList.remove('is-open');
+        panelEl.setAttribute('aria-hidden', 'true');
 
-        var anchor = toggle ? qs('a', toggle) : null;
+        var anchor = toggleEl ? qs('a', toggleEl) : null;
         if (anchor) {
             anchor.classList.remove('is-active');
             anchor.setAttribute('aria-expanded', 'false');
-            var count = Number(toggle ? toggle.dataset.fpAdminNoticesCount || '0' : '0');
+            var count = Number(toggleEl ? toggleEl.dataset.fpAdminNoticesCount || '0' : '0');
             var label = i18n.openPanel || i18n.title || 'Notifiche';
             anchor.setAttribute('aria-label', formatAriaLabel(label, count));
         }
@@ -169,13 +591,174 @@
             : anchor;
 
         if (focusTarget) {
-            focusTarget.focus({ preventScroll: true });
+            try {
+                focusTarget.focus({ preventScroll: true });
+            } catch (err) {
+                // Ignore focus issues
+            }
         }
 
         lastFocusedElement = null;
+        disableFocusTrap();
+        emit('fpAdminNotices:close', {
+            count: getActiveNotices().length
+        });
     }
 
-    function setupMutationObserver(panel, toggle) {
+    function enableFocusTrap() {
+        if (!panelEl) {
+            return;
+        }
+        disableFocusTrap();
+
+        focusTrapHandler = function (event) {
+            if (event.key !== 'Tab') {
+                return;
+            }
+            var focusable = qsa('a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])', panelEl)
+                .filter(function (el) {
+                    return el.offsetParent !== null;
+                });
+            if (!focusable.length) {
+                event.preventDefault();
+                return;
+            }
+            var first = focusable[0];
+            var last = focusable[focusable.length - 1];
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        panelEl.addEventListener('keydown', focusTrapHandler);
+    }
+
+    function disableFocusTrap() {
+        if (!panelEl || !focusTrapHandler) {
+            return;
+        }
+        panelEl.removeEventListener('keydown', focusTrapHandler);
+        focusTrapHandler = null;
+    }
+
+    function togglePanel(event) {
+        if (event) {
+            event.preventDefault();
+        }
+        if (!panelEl) {
+            return;
+        }
+        var isOpen = panelEl.classList.contains('is-open');
+        if (isOpen) {
+            closePanel();
+        } else {
+            openPanel();
+        }
+    }
+
+    function setupFilterControls() {
+        var buttons = qsa('.fp-admin-notices-filter', panelEl);
+        buttons.forEach(function (button) {
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+                var filter = button.getAttribute('data-filter') || 'all';
+                state.filter = filter;
+                buttons.forEach(function (btn) {
+                    btn.classList.toggle('is-active', btn === button);
+                });
+                renderList();
+            });
+        });
+    }
+
+    function bulkSetDismissed(notices, dismissed) {
+        if (!Array.isArray(notices) || !notices.length) {
+            return;
+        }
+
+        var changed = [];
+
+        notices.forEach(function (notice) {
+            if (!notice || notice.dismissed === dismissed) {
+                return;
+            }
+
+            notice.dismissed = dismissed;
+            if (dismissed) {
+                state.dismissed.add(notice.id);
+            } else {
+                state.dismissed.delete(notice.id);
+                hideOriginalNotice(notice.node);
+            }
+            changed.push(notice.id);
+        });
+
+        if (!changed.length) {
+            return;
+        }
+
+        updateCount();
+        renderList();
+        persistNoticeState(changed, dismissed);
+    }
+
+    function setupBulkActions() {
+        ensureBulkActionElements();
+
+        if (bulkActionEls.markRead) {
+            bulkActionEls.markRead.addEventListener('click', function (event) {
+                event.preventDefault();
+                bulkSetDismissed(getFilteredNotices({ includeDismissed: true }).filter(function (notice) {
+                    return !notice.dismissed;
+                }), true);
+            });
+        }
+
+        if (bulkActionEls.markUnread) {
+            bulkActionEls.markUnread.addEventListener('click', function (event) {
+                event.preventDefault();
+                bulkSetDismissed(getFilteredNotices({ includeDismissed: true }).filter(function (notice) {
+                    return notice.dismissed;
+                }), false);
+            });
+        }
+
+        if (bulkActionEls.toggleArchived) {
+            bulkActionEls.toggleArchived.addEventListener('click', function (event) {
+                event.preventDefault();
+                state.showDismissed = !state.showDismissed;
+                renderList();
+            });
+        }
+
+        updateBulkActionsState();
+    }
+
+    function setupSearchControl() {
+        var searchInput = qs('#fp-admin-notices-search', panelEl);
+        if (!searchInput) {
+            return;
+        }
+        searchInput.addEventListener('input', function () {
+            state.search = searchInput.value.trim().toLowerCase();
+            renderList();
+        });
+    }
+
+    function setupKeyboardShortcuts() {
+        document.addEventListener('keydown', function (event) {
+            if (event.altKey && event.shiftKey && (event.key === 'N' || event.key === 'n')) {
+                event.preventDefault();
+                togglePanel();
+            }
+        });
+    }
+
+    function setupMutationObserver() {
         var target = qs('#wpbody-content');
         if (!target) {
             return;
@@ -186,7 +769,12 @@
             if (!scheduled) {
                 scheduled = true;
                 window.requestAnimationFrame(function () {
-                    renderNotices(panel, toggle);
+                    var result = syncNotices();
+                    renderList();
+                    updateCount();
+                    if (result.newCritical && state.autoOpenCritical && panelEl && !panelEl.classList.contains('is-open')) {
+                        openPanel();
+                    }
                     scheduled = false;
                 });
             }
@@ -199,38 +787,19 @@
     }
 
     ready(function () {
-        var panel = document.getElementById('fp-admin-notices-panel');
-        var toggle = document.getElementById('wp-admin-bar-fp-admin-notices-toggle');
+        panelEl = document.getElementById('fp-admin-notices-panel');
+        toggleEl = document.getElementById('wp-admin-bar-fp-admin-notices-toggle');
 
-        if (!panel || !toggle) {
+        if (!panelEl || !toggleEl) {
             return;
         }
 
-        renderNotices(panel, toggle);
-        setupMutationObserver(panel, toggle);
-
-        var overlay = qs('.fp-admin-notices-panel__overlay', panel);
-        var closeButton = qs('.fp-admin-notices-panel__close', panel);
-        var toggleAnchor = qs('a', toggle);
-
+        var toggleAnchor = qs('a', toggleEl);
         if (toggleAnchor) {
             toggleAnchor.setAttribute('role', 'button');
             toggleAnchor.setAttribute('aria-expanded', 'false');
-            toggleAnchor.setAttribute('aria-controls', panel.id);
+            toggleAnchor.setAttribute('aria-controls', panelEl.id);
             toggleAnchor.setAttribute('aria-label', i18n.openPanel || i18n.title || 'Notifiche');
-        }
-
-        function togglePanel(event) {
-            event.preventDefault();
-            var isOpen = panel.classList.contains('is-open');
-            if (isOpen) {
-                closePanel(panel, toggle);
-            } else {
-                openPanel(panel, toggle);
-            }
-        }
-
-        if (toggleAnchor) {
             toggleAnchor.addEventListener('click', togglePanel);
             toggleAnchor.addEventListener('keydown', function (event) {
                 if (event.key === 'Enter' || event.key === ' ') {
@@ -239,24 +808,37 @@
             });
         }
 
+        var overlay = qs('.fp-admin-notices-panel__overlay', panelEl);
         if (overlay) {
             overlay.addEventListener('click', function (event) {
                 event.preventDefault();
-                closePanel(panel, toggle);
+                closePanel();
             });
         }
 
+        var closeButton = qs('.fp-admin-notices-panel__close', panelEl);
         if (closeButton) {
             closeButton.addEventListener('click', function (event) {
                 event.preventDefault();
-                closePanel(panel, toggle);
+                closePanel();
             });
         }
 
         document.addEventListener('keydown', function (event) {
-            if (event.key === 'Escape' && panel.classList.contains('is-open')) {
-                closePanel(panel, toggle);
+            if (event.key === 'Escape' && panelEl.classList.contains('is-open')) {
+                closePanel();
             }
         });
+
+        syncNotices();
+        renderList();
+        previousActiveCount = getActiveNotices().length;
+        updateCount();
+
+        setupFilterControls();
+        setupBulkActions();
+        setupSearchControl();
+        setupMutationObserver();
+        setupKeyboardShortcuts();
     });
 })();

--- a/fp-admin-notices.php
+++ b/fp-admin-notices.php
@@ -15,13 +15,27 @@ if ( ! class_exists( 'FP_Admin_Notices' ) ) {
      * Gestisce il pannello delle admin notices.
      */
     class FP_Admin_Notices {
+        const OPTION_NAME   = 'fp_admin_notices_settings';
+        const USER_META_KEY = 'fp_admin_notices_dismissed';
+
         /**
          * Avvia gli hook principali del plugin.
          */
         public static function init() {
+            add_action( 'init', array( __CLASS__, 'load_textdomain' ) );
+            add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
+            add_action( 'admin_menu', array( __CLASS__, 'register_settings_page' ) );
             add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
             add_action( 'admin_footer', array( __CLASS__, 'render_panel_markup' ) );
             add_action( 'admin_bar_menu', array( __CLASS__, 'register_admin_bar_entry' ), 100 );
+            add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
+        }
+
+        /**
+         * Carica le traduzioni del plugin.
+         */
+        public static function load_textdomain() {
+            load_plugin_textdomain( 'fp-admin-notices', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
         }
 
         /**
@@ -46,6 +60,10 @@ if ( ! class_exists( 'FP_Admin_Notices' ) ) {
          * Carica gli assets nel back-end.
          */
         public static function enqueue_assets() {
+            if ( ! self::current_user_can_view() || ! self::should_render_on_screen() ) {
+                return;
+            }
+
             $handle  = 'fp-admin-notices';
             $version = self::get_version();
 
@@ -59,7 +77,7 @@ if ( ! class_exists( 'FP_Admin_Notices' ) ) {
             wp_enqueue_script(
                 $handle,
                 plugin_dir_url( __FILE__ ) . 'assets/js/admin-notices.js',
-                array(),
+                array( 'wp-i18n' ),
                 $version,
                 true
             );
@@ -70,12 +88,43 @@ if ( ! class_exists( 'FP_Admin_Notices' ) ) {
                 array(
                     'i18n' => array(
                         'title'      => __( 'Notifiche', 'fp-admin-notices' ),
-                        'noNotices'  => __( 'Nessuna notifica da mostrare.', 'fp-admin-notices' ),
-                        'openPanel'  => __( 'Apri il pannello notifiche', 'fp-admin-notices' ),
-                        'closePanel' => __( 'Chiudi il pannello notifiche', 'fp-admin-notices' ),
+                        'noNotices'            => __( 'Nessuna notifica da mostrare.', 'fp-admin-notices' ),
+                        'noMatches'            => __( 'Nessuna notifica corrisponde ai filtri applicati.', 'fp-admin-notices' ),
+                        'noUnreadMatches'      => __( 'Tutte le notifiche corrispondenti sono archiviate. Mostrale per gestirle.', 'fp-admin-notices' ),
+                        'openPanel'            => __( 'Apri il pannello notifiche', 'fp-admin-notices' ),
+                        'closePanel'           => __( 'Chiudi il pannello notifiche', 'fp-admin-notices' ),
+                        'markRead'             => __( 'Segna come letta', 'fp-admin-notices' ),
+                        'markUnread'           => __( 'Segna come non letta', 'fp-admin-notices' ),
+                        'markAllRead'          => __( 'Segna tutte come lette', 'fp-admin-notices' ),
+                        'markAllUnread'        => __( 'Segna tutte come non lette', 'fp-admin-notices' ),
+                        'showDismissed'        => __( 'Mostra archiviate', 'fp-admin-notices' ),
+                        'hideDismissed'        => __( 'Nascondi archiviate', 'fp-admin-notices' ),
+                        'showNotice'           => __( 'Mostra nella pagina', 'fp-admin-notices' ),
+                        'filtersLabel'         => __( 'Filtra le notifiche', 'fp-admin-notices' ),
+                        'filterAll'            => __( 'Tutte', 'fp-admin-notices' ),
+                        'filterError'          => __( 'Errori', 'fp-admin-notices' ),
+                        'filterWarning'        => __( 'Avvisi', 'fp-admin-notices' ),
+                        'filterSuccess'        => __( 'Successi', 'fp-admin-notices' ),
+                        'filterInfo'           => __( 'Informazioni', 'fp-admin-notices' ),
+                        'searchPlaceholder'    => __( 'Cerca notifiche…', 'fp-admin-notices' ),
+                        'newNoticeAnnouncement'=> __( 'Nuove notifiche disponibili', 'fp-admin-notices' ),
+                        'toggleShortcut'       => __( 'Scorciatoia: premi Alt+Shift+N per aprire o chiudere il pannello notifiche.', 'fp-admin-notices' ),
                     ),
+                    'rest'      => array(
+                        'url'   => esc_url_raw( rest_url( 'fp-admin-notices/v1/notices' ) ),
+                        'nonce' => wp_create_nonce( 'wp_rest' ),
+                    ),
+                    'settings'  => array(
+                        'includeUpdateNag' => (bool) self::get_setting( 'include_update_nag', false ),
+                        'autoOpenCritical' => (bool) self::get_setting( 'auto_open_critical', true ),
+                        'filtersEnabled'   => true,
+                        'allowedScreens'   => (array) self::get_setting( 'allowed_screens', array() ),
+                    ),
+                    'dismissed' => self::get_dismissed_notice_ids(),
                 )
             );
+
+            wp_set_script_translations( $handle, 'fp-admin-notices', plugin_dir_path( __FILE__ ) . 'languages' );
         }
 
         /**
@@ -84,7 +133,7 @@ if ( ! class_exists( 'FP_Admin_Notices' ) ) {
          * @param WP_Admin_Bar $admin_bar Istanza della admin bar.
          */
         public static function register_admin_bar_entry( $admin_bar ) {
-            if ( ! current_user_can( 'read' ) ) {
+            if ( ! self::current_user_can_view() || ! self::should_render_on_screen() ) {
                 return;
             }
 
@@ -111,7 +160,7 @@ if ( ! class_exists( 'FP_Admin_Notices' ) ) {
          * Stampa il markup del pannello nel footer amministrativo.
          */
         public static function render_panel_markup() {
-            if ( ! current_user_can( 'read' ) ) {
+            if ( ! self::current_user_can_view() || ! self::should_render_on_screen() ) {
                 return;
             }
             ?>
@@ -122,12 +171,470 @@ if ( ! class_exists( 'FP_Admin_Notices' ) ) {
                         <h2 id="fp-admin-notices-title"><?php esc_html_e( 'Notifiche amministratore', 'fp-admin-notices' ); ?></h2>
                         <button type="button" class="fp-admin-notices-panel__close" aria-label="<?php echo esc_attr_x( 'Chiudi', 'close panel button', 'fp-admin-notices' ); ?>">&times;</button>
                     </header>
-                    <div class="fp-admin-notices-panel__body" tabindex="0">
-                        <div class="fp-admin-notices-panel__list" role="region" aria-live="polite" aria-relevant="all"></div>
+                    <div class="fp-admin-notices-panel__controls" role="search" aria-label="<?php esc_attr_e( 'Strumenti di ricerca e filtro per le notifiche', 'fp-admin-notices' ); ?>">
+                        <div class="fp-admin-notices-panel__filters" role="group" aria-label="<?php esc_attr_e( 'Filtri per severità', 'fp-admin-notices' ); ?>">
+                            <button type="button" class="fp-admin-notices-filter is-active" data-filter="all"><?php esc_html_e( 'Tutte', 'fp-admin-notices' ); ?></button>
+                            <button type="button" class="fp-admin-notices-filter" data-filter="error"><?php esc_html_e( 'Errori', 'fp-admin-notices' ); ?></button>
+                            <button type="button" class="fp-admin-notices-filter" data-filter="warning"><?php esc_html_e( 'Avvisi', 'fp-admin-notices' ); ?></button>
+                            <button type="button" class="fp-admin-notices-filter" data-filter="success"><?php esc_html_e( 'Successi', 'fp-admin-notices' ); ?></button>
+                            <button type="button" class="fp-admin-notices-filter" data-filter="info"><?php esc_html_e( 'Informazioni', 'fp-admin-notices' ); ?></button>
+                        </div>
+                        <label class="screen-reader-text" for="fp-admin-notices-search"><?php esc_html_e( 'Cerca notifiche', 'fp-admin-notices' ); ?></label>
+                        <input type="search" id="fp-admin-notices-search" class="fp-admin-notices-search" placeholder="<?php esc_attr_e( 'Cerca notifiche…', 'fp-admin-notices' ); ?>" autocomplete="off" />
                     </div>
+                    <div class="fp-admin-notices-panel__bulk-actions" role="group" aria-label="<?php esc_attr_e( 'Azioni rapide sulle notifiche', 'fp-admin-notices' ); ?>">
+                        <button type="button" class="fp-admin-notices-panel__bulk-action fp-admin-notices-panel__bulk-action--read"><?php esc_html_e( 'Segna tutte come lette', 'fp-admin-notices' ); ?></button>
+                        <button type="button" class="fp-admin-notices-panel__bulk-action fp-admin-notices-panel__bulk-action--unread"><?php esc_html_e( 'Segna tutte come non lette', 'fp-admin-notices' ); ?></button>
+                        <button type="button" class="fp-admin-notices-panel__bulk-action fp-admin-notices-panel__bulk-action--toggle-archived" aria-pressed="false"><?php esc_html_e( 'Mostra archiviate', 'fp-admin-notices' ); ?></button>
+                    </div>
+                    <div class="fp-admin-notices-panel__body" tabindex="0">
+                        <?php do_action( 'fp_admin_notices_panel_before_list' ); ?>
+                        <div class="fp-admin-notices-panel__list" role="region" aria-live="polite" aria-relevant="all"></div>
+                        <?php do_action( 'fp_admin_notices_panel_after_list' ); ?>
+                    </div>
+                    <p class="fp-admin-notices-panel__announcement screen-reader-text" aria-live="assertive" aria-atomic="true"></p>
                 </div>
             </div>
             <?php
+        }
+
+        /**
+         * Registra le impostazioni del plugin.
+         */
+        public static function register_settings() {
+            register_setting(
+                'fp_admin_notices_settings',
+                self::OPTION_NAME,
+                array(
+                    'type'              => 'array',
+                    'sanitize_callback' => array( __CLASS__, 'sanitize_settings' ),
+                    'default'           => array(
+                        'allowed_roles'      => array( 'administrator' ),
+                        'include_update_nag' => false,
+                        'auto_open_critical' => true,
+                    ),
+                )
+            );
+
+            add_settings_section(
+                'fp_admin_notices_settings_section',
+                __( 'Preferenze pannello notifiche', 'fp-admin-notices' ),
+                '__return_false',
+                'fp_admin_notices_settings'
+            );
+
+            add_settings_field(
+                'fp_admin_notices_roles',
+                __( 'Ruoli abilitati', 'fp-admin-notices' ),
+                array( __CLASS__, 'render_roles_field' ),
+                'fp_admin_notices_settings',
+                'fp_admin_notices_settings_section'
+            );
+
+            add_settings_field(
+                'fp_admin_notices_include_update_nag',
+                __( 'Includi avvisi di aggiornamento', 'fp-admin-notices' ),
+                array( __CLASS__, 'render_include_update_nag_field' ),
+                'fp_admin_notices_settings',
+                'fp_admin_notices_settings_section'
+            );
+
+            add_settings_field(
+                'fp_admin_notices_auto_open_critical',
+                __( 'Apri automaticamente per errori critici', 'fp-admin-notices' ),
+                array( __CLASS__, 'render_auto_open_field' ),
+                'fp_admin_notices_settings',
+                'fp_admin_notices_settings_section'
+            );
+
+            add_settings_field(
+                'fp_admin_notices_allowed_screens',
+                __( 'Limita il caricamento alle schermate', 'fp-admin-notices' ),
+                array( __CLASS__, 'render_allowed_screens_field' ),
+                'fp_admin_notices_settings',
+                'fp_admin_notices_settings_section'
+            );
+        }
+
+        /**
+         * Aggiunge la pagina delle impostazioni.
+         */
+        public static function register_settings_page() {
+            add_options_page(
+                __( 'Pannello notifiche', 'fp-admin-notices' ),
+                __( 'Pannello notifiche', 'fp-admin-notices' ),
+                'manage_options',
+                'fp-admin-notices',
+                array( __CLASS__, 'render_settings_page' )
+            );
+        }
+
+        /**
+         * Stampa la pagina delle impostazioni.
+         */
+        public static function render_settings_page() {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                return;
+            }
+            ?>
+            <div class="wrap">
+                <h1><?php esc_html_e( 'Impostazioni pannello notifiche', 'fp-admin-notices' ); ?></h1>
+                <form action="options.php" method="post">
+                    <?php
+                    settings_fields( 'fp_admin_notices_settings' );
+                    do_settings_sections( 'fp_admin_notices_settings' );
+                    submit_button();
+                    ?>
+                </form>
+            </div>
+            <?php
+        }
+
+        /**
+         * Campo impostazioni per i ruoli.
+         */
+        public static function render_roles_field() {
+            $settings = self::get_settings();
+            $allowed  = isset( $settings['allowed_roles'] ) ? (array) $settings['allowed_roles'] : array( 'administrator' );
+            $editable = get_editable_roles();
+            ?>
+            <fieldset>
+                <legend class="screen-reader-text"><?php esc_html_e( 'Ruoli abilitati', 'fp-admin-notices' ); ?></legend>
+                <?php foreach ( $editable as $role_key => $role ) :
+                    $checked = in_array( $role_key, $allowed, true );
+                    ?>
+                    <label>
+                        <input type="checkbox" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[allowed_roles][]" value="<?php echo esc_attr( $role_key ); ?>" <?php checked( $checked ); ?> />
+                        <?php echo esc_html( translate_user_role( $role['name'] ) ); ?>
+                    </label><br />
+                <?php endforeach; ?>
+                <p class="description"><?php esc_html_e( 'Gli utenti con uno dei ruoli selezionati potranno utilizzare il pannello notifiche.', 'fp-admin-notices' ); ?></p>
+            </fieldset>
+            <?php
+        }
+
+        /**
+         * Campo impostazioni per includere gli update nag.
+         */
+        public static function render_include_update_nag_field() {
+            $settings = self::get_settings();
+            $value    = ! empty( $settings['include_update_nag'] );
+            ?>
+            <label>
+                <input type="checkbox" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[include_update_nag]" value="1" <?php checked( $value ); ?> />
+                <?php esc_html_e( 'Mostra anche gli avvisi di aggiornamento (update nag).', 'fp-admin-notices' ); ?>
+            </label>
+            <?php
+        }
+
+        /**
+         * Campo impostazioni per l'apertura automatica del pannello.
+         */
+        public static function render_auto_open_field() {
+            $settings = self::get_settings();
+            $value    = ! empty( $settings['auto_open_critical'] );
+            ?>
+            <label>
+                <input type="checkbox" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[auto_open_critical]" value="1" <?php checked( $value ); ?> />
+                <?php esc_html_e( 'Apri automaticamente il pannello quando arrivano errori critici.', 'fp-admin-notices' ); ?>
+            </label>
+            <?php
+        }
+
+        /**
+         * Campo impostazioni per limitare il caricamento alle schermate specificate.
+         */
+        public static function render_allowed_screens_field() {
+            $settings = self::get_settings();
+            $screens  = isset( $settings['allowed_screens'] ) && is_array( $settings['allowed_screens'] )
+                ? implode( "\n", array_map( 'sanitize_text_field', $settings['allowed_screens'] ) )
+                : '';
+            ?>
+            <textarea
+                name="<?php echo esc_attr( self::OPTION_NAME ); ?>[allowed_screens]"
+                rows="4"
+                cols="40"
+                class="large-text code"
+                placeholder="dashboard\nplugins\nsettings_page_my-plugin"
+            ><?php echo esc_textarea( $screens ); ?></textarea>
+            <p class="description">
+                <?php esc_html_e( 'Inserisci gli ID delle schermate (uno per riga) in cui caricare il pannello. Lascia vuoto per abilitarlo ovunque.', 'fp-admin-notices' ); ?>
+            </p>
+            <?php
+        }
+
+        /**
+         * Sanitizza i valori delle impostazioni.
+         *
+         * @param array $settings Valori grezzi.
+         * @return array
+         */
+        public static function sanitize_settings( $settings ) {
+            $settings = is_array( $settings ) ? $settings : array();
+
+            $allowed_roles = array();
+            if ( ! empty( $settings['allowed_roles'] ) && is_array( $settings['allowed_roles'] ) ) {
+                $editable = get_editable_roles();
+                foreach ( $settings['allowed_roles'] as $role ) {
+                    if ( isset( $editable[ $role ] ) ) {
+                        $allowed_roles[] = sanitize_key( $role );
+                    }
+                }
+            }
+
+            if ( empty( $allowed_roles ) ) {
+                $allowed_roles[] = 'administrator';
+            }
+
+            $allowed_screens = array();
+            if ( ! empty( $settings['allowed_screens'] ) ) {
+                $raw_screens = is_array( $settings['allowed_screens'] )
+                    ? $settings['allowed_screens']
+                    : preg_split( '/[\r\n]+/', (string) $settings['allowed_screens'] );
+
+                foreach ( (array) $raw_screens as $screen_id ) {
+                    $screen_id = sanitize_key( trim( (string) $screen_id ) );
+                    if ( '' !== $screen_id ) {
+                        $allowed_screens[] = $screen_id;
+                    }
+                }
+            }
+
+            $allowed_screens = array_values( array_unique( $allowed_screens ) );
+
+            return array(
+                'allowed_roles'      => $allowed_roles,
+                'include_update_nag' => ! empty( $settings['include_update_nag'] ),
+                'auto_open_critical' => ! empty( $settings['auto_open_critical'] ),
+                'allowed_screens'    => $allowed_screens,
+            );
+        }
+
+        /**
+         * Restituisce le impostazioni memorizzate.
+         *
+         * @return array
+         */
+        protected static function get_settings() {
+            $defaults = array(
+                'allowed_roles'      => array( 'administrator' ),
+                'include_update_nag' => false,
+                'auto_open_critical' => true,
+                'allowed_screens'    => array(),
+            );
+
+            $settings = get_option( self::OPTION_NAME, array() );
+
+            if ( ! is_array( $settings ) ) {
+                $settings = array();
+            }
+
+            return wp_parse_args( $settings, $defaults );
+        }
+
+        /**
+         * Restituisce un valore specifico delle impostazioni.
+         *
+         * @param string $key     Nome dell'opzione.
+         * @param mixed  $default Valore di fallback.
+         * @return mixed
+         */
+        protected static function get_setting( $key, $default = null ) {
+            $settings = self::get_settings();
+
+            return isset( $settings[ $key ] ) ? $settings[ $key ] : $default;
+        }
+
+        /**
+         * Verifica se l'utente corrente può usare il pannello.
+         *
+         * @return bool
+         */
+        protected static function current_user_can_view() {
+            if ( ! is_user_logged_in() ) {
+                return false;
+            }
+
+            $user  = wp_get_current_user();
+            $roles = (array) self::get_setting( 'allowed_roles', array( 'administrator' ) );
+
+            return (bool) array_intersect( $roles, (array) $user->roles );
+        }
+
+        /**
+         * Verifica se il pannello deve essere caricato nella schermata corrente.
+         *
+         * @return bool
+         */
+        protected static function should_render_on_screen() {
+            $allowed_screens = (array) self::get_setting( 'allowed_screens', array() );
+            $allowed_screens = apply_filters( 'fp_admin_notices_allowed_screens', $allowed_screens );
+
+            $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : false;
+
+            if ( empty( $allowed_screens ) ) {
+                /**
+                 * Permette di forzare o impedire il rendering del pannello a livello globale.
+                 *
+                 * @param bool             $render Indica se il pannello deve essere mostrato.
+                 * @param WP_Screen|false  $screen Schermata corrente se disponibile.
+                 */
+                return (bool) apply_filters( 'fp_admin_notices_should_render', true, $screen );
+            }
+
+            if ( ! $screen ) {
+                return (bool) apply_filters( 'fp_admin_notices_should_render', false, $screen );
+            }
+
+            $screen_id   = sanitize_key( $screen->id );
+            $screen_base = sanitize_key( $screen->base );
+
+            $matches = in_array( $screen_id, $allowed_screens, true ) || in_array( $screen_base, $allowed_screens, true );
+
+            return (bool) apply_filters( 'fp_admin_notices_should_render', $matches, $screen );
+        }
+
+        /**
+         * Restituisce gli ID delle notifiche dismesse dall'utente.
+         *
+         * @return array
+         */
+        protected static function get_dismissed_notice_ids() {
+            $user_id = get_current_user_id();
+
+            if ( ! $user_id ) {
+                return array();
+            }
+
+            $dismissed = get_user_meta( $user_id, self::USER_META_KEY, true );
+
+            return is_array( $dismissed ) ? array_values( array_unique( array_map( 'sanitize_text_field', $dismissed ) ) ) : array();
+        }
+
+        /**
+         * Aggiorna lo stato di una notifica per l'utente.
+         *
+         * @param string $notice_id ID della notifica.
+         * @param bool   $dismissed Stato da applicare.
+         */
+        protected static function update_notice_state( $notice_id, $dismissed ) {
+            $user_id = get_current_user_id();
+
+            if ( ! $user_id || ! $notice_id ) {
+                return;
+            }
+
+            $stored    = self::get_dismissed_notice_ids();
+            $notice_id = sanitize_text_field( $notice_id );
+
+            if ( $dismissed ) {
+                if ( ! in_array( $notice_id, $stored, true ) ) {
+                    $stored[] = $notice_id;
+                }
+            } else {
+                $stored = array_values( array_diff( $stored, array( $notice_id ) ) );
+            }
+
+            update_user_meta( $user_id, self::USER_META_KEY, $stored );
+        }
+
+        /**
+         * Registra le rotte REST utilizzate dal pannello.
+         */
+        public static function register_rest_routes() {
+            register_rest_route(
+                'fp-admin-notices/v1',
+                '/notices',
+                array(
+                    array(
+                        'methods'             => WP_REST_Server::CREATABLE,
+                        'callback'            => array( __CLASS__, 'rest_update_notice_state' ),
+                        'permission_callback' => array( __CLASS__, 'rest_permission_callback' ),
+                        'args'                => array(
+                            'notice_id' => array(
+                                'type'     => 'string',
+                                'required' => false,
+                            ),
+                            'notice_ids' => array(
+                                'type'     => 'array',
+                                'items'    => array(
+                                    'type' => 'string',
+                                ),
+                                'required' => false,
+                            ),
+                            'dismissed' => array(
+                                'type'    => 'boolean',
+                                'default' => true,
+                            ),
+                        ),
+                    ),
+                )
+            );
+        }
+
+        /**
+         * Controlla i permessi per la rotta REST.
+         *
+         * @return bool
+         */
+        public static function rest_permission_callback() {
+            return self::current_user_can_view();
+        }
+
+        /**
+         * Aggiorna lo stato via REST.
+         *
+         * @param WP_REST_Request $request Richiesta REST.
+         * @return WP_REST_Response
+         */
+        public static function rest_update_notice_state( WP_REST_Request $request ) {
+            $dismissed = filter_var( $request->get_param( 'dismissed' ), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+
+            if ( null === $dismissed ) {
+                $dismissed = true;
+            }
+
+            $notice_ids = array();
+
+            $notice_ids_param = $request->get_param( 'notice_ids' );
+            if ( is_array( $notice_ids_param ) ) {
+                foreach ( $notice_ids_param as $id ) {
+                    $id = sanitize_text_field( $id );
+                    if ( '' !== $id ) {
+                        $notice_ids[] = $id;
+                    }
+                }
+            }
+
+            $single_notice_id = $request->get_param( 'notice_id' );
+            if ( is_string( $single_notice_id ) && '' !== $single_notice_id ) {
+                $notice_ids[] = sanitize_text_field( $single_notice_id );
+            }
+
+            $notice_ids = array_values( array_unique( array_filter( $notice_ids ) ) );
+
+            if ( empty( $notice_ids ) ) {
+                return new WP_Error(
+                    'fp_admin_notices_missing_notice',
+                    __( 'Nessuna notifica specificata.', 'fp-admin-notices' ),
+                    array( 'status' => 400 )
+                );
+            }
+
+            foreach ( $notice_ids as $notice_id ) {
+                self::update_notice_state( $notice_id, (bool) $dismissed );
+            }
+
+            $response = array(
+                'notice_ids' => $notice_ids,
+                'dismissed'  => (bool) $dismissed,
+            );
+
+            if ( 1 === count( $notice_ids ) ) {
+                $response['notice_id'] = $notice_ids[0];
+            }
+
+            return rest_ensure_response( $response );
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce quick actions in the admin panel to mark all filtered notices read/unread and to show archived notices on demand
- update the JavaScript to manage the new controls, provide bulk REST persistence, and surface filter state in list update events
- extend REST parameters, localised strings, and styling/documentation to cover bulk operations and archived notice visibility

## Testing
- php -l fp-admin-notices.php

------
https://chatgpt.com/codex/tasks/task_e_68d59ee4fa20832f9dd42724bb7fcbdc